### PR TITLE
Add support for 64-bit numerical data types

### DIFF
--- a/ConfigGenerator.Tests/TestFiles/appsettings.json
+++ b/ConfigGenerator.Tests/TestFiles/appsettings.json
@@ -10,8 +10,12 @@
   "DuplicateEntryOnlyShowsOnce": false,
   "IntValue": 1,
   "DoubleValue": 2.2,
+  "LongValue": 9223372036854775807,
+  "ULongValue": 18446744073709551615,
   "ArrayWithDoubles": [1.1, 2.245, 4.67],
   "ArrayWithStrings": [ "Key1", "Value 1" ],
   "ArrayWithInts": [ 1, 2 ],
-  "ArrayWithBools": [ true, false, true ]  
+  "ArrayWithBools": [ true, false, true ],
+  "ArrayWithLongs": [ 9223372036854775807, 1234567890123456789 ],
+  "ArrayWithULongs": [ 18446744073709551615, 1234567890123456789 ]
 }

--- a/ConfigGenerator.Tests/TestFiles/expected.cs
+++ b/ConfigGenerator.Tests/TestFiles/expected.cs
@@ -1,5 +1,4 @@
-﻿
-using System;
+﻿using System;
 using System.Collections.Generic;
 
 namespace ApplicationConfig
@@ -11,10 +10,14 @@ namespace ApplicationConfig
         public bool DuplicateEntryOnlyShowsOnce { get; set; }
         public int IntValue { get; set; }
         public double DoubleValue { get; set; }
+        public long LongValue { get; set; }
+        public ulong ULongValue { get; set; }
         public IEnumerable<double> ArrayWithDoubles { get; set; }
         public IEnumerable<string> ArrayWithStrings { get; set; }
         public IEnumerable<int> ArrayWithInts { get; set; }
         public IEnumerable<bool> ArrayWithBools { get; set; }
+        public IEnumerable<long> ArrayWithLongs { get; set; }
+        public IEnumerable<ulong> ArrayWithULongs { get; set; }
         public bool ShowDeveloperWarnings { get; set; }
         public Logging Logging { get; set; }
     }

--- a/src/ConfigGenerator.csproj
+++ b/src/ConfigGenerator.csproj
@@ -10,13 +10,12 @@
 	</PropertyGroup>
 
 	<PropertyGroup>
-		<PackageId>ConfigurationGenerator</PackageId>
+		<PackageId>ConfigGenerator</PackageId>
 		<RepositoryType>git</RepositoryType>
-		<RepositoryUrl>https://github.com/pattrigue/config-poco-generator</RepositoryUrl>
-		<Description>Generates POCO classes from your appsettingsfiles.
-Fork of https://github.com/albertromkes/config-poco-generator.</Description>
-		<Authors>Albert Romkes &amp; Pattrigue</Authors>
-		<Version>1.0.5</Version>
+		<RepositoryUrl>https://github.com/albertromkes/config-poco-generator</RepositoryUrl>
+		<Description>Generates POCO classes from your appsettingsfiles</Description>
+		<Authors>Albert Romkes</Authors>
+		<Version>1.0.4</Version>
 		<PackageReadmeFile>README.md</PackageReadmeFile>		
 	</PropertyGroup>
 

--- a/src/ConfigGenerator.csproj
+++ b/src/ConfigGenerator.csproj
@@ -10,12 +10,13 @@
 	</PropertyGroup>
 
 	<PropertyGroup>
-		<PackageId>ConfigGenerator</PackageId>
+		<PackageId>ConfigurationGenerator</PackageId>
 		<RepositoryType>git</RepositoryType>
-		<RepositoryUrl>https://github.com/albertromkes/config-poco-generator</RepositoryUrl>
-		<Description>Generates POCO classes from your appsettingsfiles</Description>
-		<Authors>Albert Romkes</Authors>
-		<Version>1.0.4</Version>
+		<RepositoryUrl>https://github.com/pattrigue/config-poco-generator</RepositoryUrl>
+		<Description>Generates POCO classes from your appsettingsfiles.
+Fork of https://github.com/albertromkes/config-poco-generator.</Description>
+		<Authors>Albert Romkes &amp; Pattrigue</Authors>
+		<Version>1.0.5</Version>
 		<PackageReadmeFile>README.md</PackageReadmeFile>		
 	</PropertyGroup>
 

--- a/src/GenerateConfigClasses.cs
+++ b/src/GenerateConfigClasses.cs
@@ -135,10 +135,19 @@ namespace ConfigGenerator
         {
             return value.ValueKind switch
             {
-                JsonValueKind.Number => value.TryGetInt32(out _) ? "int" : "double",
+                JsonValueKind.Number => DetermineNumericType(value),
                 JsonValueKind.True or JsonValueKind.False => "bool",
                 _ => "string",
             };
+        }
+        
+        private static string DetermineNumericType(JsonElement value)
+        {
+            if (value.TryGetInt32(out _)) return "int";
+            if (value.TryGetInt64(out _)) return "long";
+            if (value.TryGetUInt64(out _)) return "ulong";
+
+            return "double"; 
         }
 
         private static string NormalizePropertyName(string originalName)


### PR DESCRIPTION
I added support for 64-bit types such as long and ulong in the configuration classes generated by our source code generator. Personally, I needed this to store IDs in my application, which use the ulong data type. Using a double caused loss of precision.
The unit test remains unchanged and still passes, however I did change the expected output to include 64-bit data types.